### PR TITLE
fix(sonar): resolve code smells and false positives

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,4 @@ sonar.sources=src
 sonar.tests=src
 sonar.test.inclusions=**/*.test.tsx,**/*.test.ts
 sonar.cpd.exclusions=src/components/ui/**/*,src/lib/utils.ts
+sonar.exclusions=src/index.css

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
-import path from 'path'
+import path from 'node:path'
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Uses node:path import and excludes Tailwind v4 CSS from analysis.