### PR TITLE
fix(sonar): add broader exclusion for src/index.css

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,5 @@ sonar.tests=src
 sonar.test.inclusions=**/*.test.tsx,**/*.test.ts
 sonar.cpd.exclusions=src/components/ui/**/*,src/lib/utils.ts
 sonar.exclusions=src/index.css
+sonar.analysis.exclusions=src/index.css
+


### PR DESCRIPTION
Excludes src/index.css from SonarQube analysis to prevent false positives due to Tailwind v4 syntax in @plugin and @custom-variant at-rules.