### PR TITLE
fix(sonar): update exclusion patterns for index.css

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,6 @@ sonar.sources=src
 sonar.tests=src
 sonar.test.inclusions=**/*.test.tsx,**/*.test.ts
 sonar.cpd.exclusions=src/components/ui/**/*,src/lib/utils.ts
-sonar.exclusions=src/index.css
-sonar.analysis.exclusions=src/index.css
+sonar.exclusions=**/src/index.css,src/index.css
+sonar.css.exclusions=**/src/index.css,src/index.css
 


### PR DESCRIPTION
Updates SonarQube exclusion patterns to ensure src/index.css is ignored, preventing false positives with Tailwind v4 syntax.