### PR TITLE
fix(content): rename Web Validator to Web Linter

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,7 +14,7 @@ const Footer = () => {
     product: [
       { name: "Documentation", href: `${MAIN_SITE}/doc` },
       { name: "Roadmap", href: `${MAIN_SITE}/roadmap` },
-      { name: "Web Validator", href: "/", current: true }, // Odkaz na tuto aplikaci
+      { name: "Web Linter", href: "/", current: true },
       { name: "GitHub App", href: `${MAIN_SITE}/github-app` },
       { name: "CLI", href: `${MAIN_SITE}/cli` },
       { name: "Chrome Extension", href: `${MAIN_SITE}/chrome-extension` },

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -48,7 +48,7 @@ const Header = () => {
       icon: GitPullRequest,
     },
     {
-      title: "Web Validator",
+      title: "Web Linter",
       href: "/",
       description: "Online linter for quick checks.",
       icon: Globe,


### PR DESCRIPTION
Unifies terminology across the ecosystem by renaming Web Validator to Web Linter.