### PR TITLE
fix(web): correct Terms of Service link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -32,7 +32,7 @@ const Footer = () => {
     ],
     legal: [
       { name: "Privacy Policy", href: `${MAIN_SITE}/privacy` },
-      { name: "Terms of Service", href: `${MAIN_SITE}/terms` },
+      { name: "Terms of Service", href: `${MAIN_SITE}/tos` },
     ],
   };
 


### PR DESCRIPTION
Changes the Terms of Service link in the footer from /terms to /tos to match the main website.