### PR TITLE
fix(weblinter): disable no-explicit-any in type definition

### DIFF
--- a/src/types/react-syntax-highlighter.d.ts
+++ b/src/types/react-syntax-highlighter.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module 'react-syntax-highlighter/dist/esm/prism' {
   import { ComponentType } from 'react';
   const Prism: ComponentType<any>;


### PR DESCRIPTION
Disables the no-explicit-any rule for the react-syntax-highlighter declaration file to satisfy linting.