### PR TITLE
perf(weblinter): disable preload for heavy chunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
     setupFiles: './src/test/setup.ts',
   },
   build: {
+    modulePreload: {
+      resolveDependencies: (filename, deps) => {
+        return deps.filter((dep) => !dep.includes('vendor-heavy'));
+      },
+    },
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
Disables module preload for the 'vendor-heavy' chunk (mermaid, syntax highlighter) to improve initial page load performance and reduce unused JavaScript reported by PageSpeed.