### PR TITLE
fix(build): resolve unused parameter in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   },
   build: {
     modulePreload: {
-      resolveDependencies: (filename, deps) => {
+      resolveDependencies: (_filename, deps) => {
         return deps.filter((dep) => !dep.includes('vendor-heavy'));
       },
     },


### PR DESCRIPTION
Fixes a TypeScript error by renaming an unused parameter in vite.config.ts to '_filename'.