### PR TITLE
chore: disable Vercel deployment for main branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,8 @@
 {
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  },
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
## Summary
Disables Vercel production deployment for main branch to prevent duplicate deployments.

## Changes
- Added `git.deploymentEnabled.main = false` to `vercel.json`
- Preview deployments for pull requests remain enabled
- Production deployment happens exclusively via GitHub Pages

## Rationale
- **Single source of truth**: GitHub Pages serves production from main branch
- **Cost optimization**: Prevents unnecessary Vercel deployments
- **Testing workflow**: Vercel previews are still available for PRs before merge

## Configuration
```json
{
  "git": {
    "deploymentEnabled": {
      "main": false
    }
  },
  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)